### PR TITLE
Use modern PHP standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,15 @@
         }
     ],
     "autoload": {
-        "classmap": [
-            "src/"
-        ]
+        "psr-4": {
+            "Gorse\\": "src/"
+        }
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"
     },
     "require": {
+        "php": "~8.2.0 || ~8.3.0",
         "guzzlehttp/guzzle": "^7.0",
         "ext-redis": "*"
     }

--- a/src/Feedback.php
+++ b/src/Feedback.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Gorse;
+
+readonly class Feedback implements \JsonSerializable
+{
+    public function __construct(
+        public string $feedbackType,
+        public string $userId,
+        public string $itemId,
+        public string $timestamp,
+        public ?string $comment = null,
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        $result = [
+            'FeedbackType' => $this->feedbackType,
+            'UserId' => $this->userId,
+            'ItemId' => $this->itemId,
+            'Timestamp' => $this->timestamp,
+        ];
+
+        if ($this->comment) {
+            $result['Comment'] = $this->comment;
+        }
+
+        return $result;
+    }
+}

--- a/src/Gorse.php
+++ b/src/Gorse.php
@@ -1,79 +1,15 @@
-<?php
+<?php declare(strict_types=1);
+
+namespace Gorse;
 
 use GuzzleHttp\Exception\GuzzleException;
 
-class User implements JsonSerializable
+final readonly class Gorse
 {
-    public string $userId;
-    public array $labels;
-
-    public function __construct(string $userId, array $labels)
-    {
-        $this->userId = $userId;
-        $this->labels = $labels;
-    }
-
-    public function jsonSerialize(): array
-    {
-        return [
-            'UserId' => $this->userId,
-            'Labels' => $this->labels,
-        ];
-    }
-
-    public static function fromJSON($json): User
-    {
-        return new User($json->UserId, $json->Labels);
-    }
-}
-
-class Feedback implements JsonSerializable
-{
-    public string $feedback_type;
-    public string $user_id;
-    public string $item_id;
-    public string $timestamp;
-
-    public function __construct(string $feedback_type, string $user_id, string $item_id, string $timestamp)
-    {
-        $this->feedback_type = $feedback_type;
-        $this->user_id = $user_id;
-        $this->item_id = $item_id;
-        $this->timestamp = $timestamp;
-    }
-
-    public function jsonSerialize(): array
-    {
-        return [
-            'FeedbackType' => $this->feedback_type,
-            'UserId' => $this->user_id,
-            'ItemId' => $this->item_id,
-            'Timestamp' => $this->timestamp,
-        ];
-    }
-}
-
-class RowAffected
-{
-    public int $rowAffected;
-
-    public static function fromJSON($json): RowAffected
-    {
-        $rowAffected = new RowAffected();
-        $rowAffected->rowAffected = $json->RowAffected;
-        return $rowAffected;
-    }
-}
-
-final class Gorse
-{
-    private string $endpoint;
-    private string $apiKey;
-
-    function __construct(string $endpoint, string $apiKey)
-    {
-        $this->endpoint = $endpoint;
-        $this->apiKey = $apiKey;
+    function __construct(
+        private string $endpoint,
+        private string $apiKey
+    ) {
     }
 
     /**
@@ -87,39 +23,44 @@ final class Gorse
     /**
      * @throws GuzzleException
      */
-    function getUser(string $user_id): User
+    function getUser(string $userId): User
     {
-        return User::fromJSON($this->request('GET', '/api/user/' . $user_id, null));
+        return User::fromJSON($this->request('GET', '/api/user/' . $userId));
     }
 
     /**
      * @throws GuzzleException
      */
-    function deleteUser(string $user_id): RowAffected
+    function deleteUser(string $userId): RowAffected
     {
-        return RowAffected::fromJSON($this->request('DELETE', '/api/user/' . $user_id, null));
+        return RowAffected::fromJSON($this->request('DELETE', '/api/user/' . $userId));
     }
 
     /**
+     * @param Feedback|Feedback[] $feedback
      * @throws GuzzleException
      */
-    function insertFeedback(array $feedback): RowAffected
+    function insertFeedback(mixed $feedback): RowAffected
     {
+        if ($feedback instanceof Feedback) {
+            $feedback = [$feedback];
+        }
+
         return RowAffected::fromJSON($this->request('POST', '/api/feedback/', $feedback));
     }
 
     /**
      * @throws GuzzleException
      */
-    function getRecommend(string $user_id): array
+    function getRecommend(string $userId): array
     {
-        return $this->request('GET', '/api/recommend/' . $user_id, null);
+        return $this->request('GET', '/api/recommend/' . $userId);
     }
 
     /**
      * @throws GuzzleException
      */
-    private function request(string $method, string $uri, $body)
+    private function request(string $method, string $uri, \JsonSerializable|array|null $body = null)
     {
         $client = new GuzzleHttp\Client(['base_uri' => $this->endpoint]);
         $options = [GuzzleHttp\RequestOptions::HEADERS => ['X-API-Key' => $this->apiKey]];
@@ -127,6 +68,7 @@ final class Gorse
             $options[GuzzleHttp\RequestOptions::JSON] = $body;
         }
         $response = $client->request($method, $uri, $options);
+
         return json_decode($response->getBody());
     }
 }

--- a/src/RowAffected.php
+++ b/src/RowAffected.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Gorse;
+
+readonly class RowAffected
+{
+    public function __construct(
+        public int $rowAffected
+    ) {
+    }
+
+    public static function fromJSON(object $json): RowAffected
+    {
+        return new RowAffected($json->RowAffected);
+    }
+}

--- a/src/User.php
+++ b/src/User.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Gorse;
+
+readonly class User implements \JsonSerializable
+{
+
+    public function __construct(
+        public string $userId,
+        public array $labels
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'UserId' => $this->userId,
+            'Labels' => $this->labels,
+        ];
+    }
+
+    public static function fromJSON($json): User
+    {
+        return new User($json->UserId, $json->Labels);
+    }
+}

--- a/test/GorseTest.php
+++ b/test/GorseTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Gorse\Feedback;
+use Gorse\Gorse;
+use Gorse\User;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
The current PHP SDK implementation lacks compatibility with modern PHP project standards, as it relies on outdated practices such as loose typing and the absence of namespaces. These limitations make it challenging to integrate the SDK effectively into new and modern PHP codebases that do follow the standards.

This Pull Request proposes a rewrite of the SDK to align it with modern PHP conventions and best practices.
Additionally, I propose expanding support to cover all available API endpoints in Gorse, as the current implementation only includes a limited subset. Before proceeding with this extended implementation, I would appreciate confirmation from the maintainer to ensure alignment with the project’s goals before continuing with these efforts.
