### PR TITLE
feat!: get_recommend now returns array of Score with X-API-Version: 2

### DIFF
--- a/src/Gorse.php
+++ b/src/Gorse.php
@@ -139,7 +139,7 @@ final class Gorse
      * Uses X-API-Version: 2 header to return scores.
      * @throws GuzzleException
      */
-    function getRecommendWithScores(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
+    function get_recommend(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
     {
         $params = ['n' => $n, 'offset' => $offset];
         if ($write_back_type) $params['write-back-type'] = $write_back_type;

--- a/src/Gorse.php
+++ b/src/Gorse.php
@@ -122,24 +122,11 @@ final class Gorse
     }
 
     /**
-     * Get recommendation for a user.
-     * @throws GuzzleException
-     */
-    function getRecommend(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
-    {
-        $params = ['n' => $n, 'offset' => $offset];
-        if ($write_back_type) $params['write-back-type'] = $write_back_type;
-        if ($write_back_delay) $params['write-back-delay'] = $write_back_delay;
-        
-        return $this->request('GET', '/api/recommend/' . urlencode($user_id), null, $params);
-    }
-
-    /**
      * Get recommendation with scores for a user.
      * Uses X-API-Version: 2 header to return scores.
      * @throws GuzzleException
      */
-    function get_recommend(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
+    function getRecommend(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
     {
         $params = ['n' => $n, 'offset' => $offset];
         if ($write_back_type) $params['write-back-type'] = $write_back_type;

--- a/src/Gorse.php
+++ b/src/Gorse.php
@@ -122,6 +122,7 @@ final class Gorse
     }
 
     /**
+     * Get recommendation for a user.
      * @throws GuzzleException
      */
     function getRecommend(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
@@ -131,6 +132,25 @@ final class Gorse
         if ($write_back_delay) $params['write-back-delay'] = $write_back_delay;
         
         return $this->request('GET', '/api/recommend/' . urlencode($user_id), null, $params);
+    }
+
+    /**
+     * Get recommendation with scores for a user.
+     * Uses X-API-Version: 2 header to return scores.
+     * @throws GuzzleException
+     */
+    function getRecommendWithScores(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
+    {
+        $params = ['n' => $n, 'offset' => $offset];
+        if ($write_back_type) $params['write-back-type'] = $write_back_type;
+        if ($write_back_delay) $params['write-back-delay'] = $write_back_delay;
+        
+        $scores = [];
+        $response = $this->requestWithHeaders('GET', '/api/recommend/' . urlencode($user_id), null, $params, ['X-API-Version' => '2']);
+        foreach ($response as $score) {
+            $scores[] = Score::fromJSON($score);
+        }
+        return $scores;
     }
     
     /**
@@ -217,7 +237,15 @@ final class Gorse
      */
     private function request(string $method, string $uri, $body, array $query = [])
     {
-        $options = [RequestOptions::HEADERS => ['X-API-Key' => $this->apiKey]];
+        return $this->requestWithHeaders($method, $uri, $body, $query, []);
+    }
+
+    /**
+     * @throws GuzzleException
+     */
+    private function requestWithHeaders(string $method, string $uri, $body, array $query = [], array $headers = [])
+    {
+        $options = [RequestOptions::HEADERS => array_merge(['X-API-Key' => $this->apiKey], $headers)];
         if ($body != null) {
             $options[RequestOptions::JSON] = $body;
         }

--- a/test/GorseTest.php
+++ b/test/GorseTest.php
@@ -4,6 +4,7 @@ use Gorse\Gorse;
 use Gorse\Model\Feedback;
 use Gorse\Model\Item;
 use Gorse\Model\User;
+use Gorse\Model\Score;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\TestCase;
@@ -86,7 +87,25 @@ final class GorseTest extends TestCase
         $client = new Gorse(self::ENDPOINT, self::API_KEY);
         $client->insertUser(new User("3000", array(), ""));
         $items = $client->getRecommend('3000', null, null, 3);
+        
+        // Check that we get an array of Score objects
         $this->assertIsArray($items);
+        $this->assertCount(3, $items);
+        
+        // Check each item is a Score instance and has expected ID
+        foreach ($items as $item) {
+            $this->assertInstanceOf(Score::class, $item);
+            $this->assertNotEmpty($item->id);
+            $this->assertIsString($item->id);
+        }
+        
+        // Check specific IDs match expected recommendations
+        $ids = array_map(function($item) {
+            return $item->id;
+        }, $items);
+        $this->assertEquals('315', $ids[0]);
+        $this->assertEquals('1432', $ids[1]);
+        $this->assertEquals('918', $ids[2]);
     }
 
     /**
@@ -99,7 +118,8 @@ final class GorseTest extends TestCase
         $items = $client->getLatest('3000', 3);
         $this->assertIsArray($items);
         foreach ($items as $item) {
-             $this->assertInstanceOf(\Gorse\Model\Score::class, $item);
+            $this->assertInstanceOf(Score::class, $item);
+            $this->assertNotEmpty($item->id);
         }
     }
 }

--- a/test/GorseTest.php
+++ b/test/GorseTest.php
@@ -98,10 +98,15 @@ final class GorseTest extends TestCase
     /**
      * @throws GuzzleException
      */
-    public function testNonPersonalized()
+    public function testLatest()
     {
         $client = new Gorse(self::ENDPOINT, self::API_KEY);
         $items = $client->getLatest('3000', 3);
+        
+        // Check IDs
         $this->assertCount(3, $items);
+        $this->assertEquals('315', $items[0]->id);
+        $this->assertEquals('1432', $items[1]->id);
+        $this->assertEquals('918', $items[2]->id);
     }
 }

--- a/test/GorseTest.php
+++ b/test/GorseTest.php
@@ -88,24 +88,11 @@ final class GorseTest extends TestCase
         $client->insertUser(new User("3000", array(), ""));
         $items = $client->getRecommend('3000', null, null, 3);
         
-        // Check that we get an array of Score objects
-        $this->assertIsArray($items);
+        // Check IDs
         $this->assertCount(3, $items);
-        
-        // Check each item is a Score instance and has expected ID
-        foreach ($items as $item) {
-            $this->assertInstanceOf(Score::class, $item);
-            $this->assertNotEmpty($item->id);
-            $this->assertIsString($item->id);
-        }
-        
-        // Check specific IDs match expected recommendations
-        $ids = array_map(function($item) {
-            return $item->id;
-        }, $items);
-        $this->assertEquals('315', $ids[0]);
-        $this->assertEquals('1432', $ids[1]);
-        $this->assertEquals('918', $ids[2]);
+        $this->assertEquals('315', $items[0]->id);
+        $this->assertEquals('1432', $items[1]->id);
+        $this->assertEquals('918', $items[2]->id);
     }
 
     /**
@@ -114,12 +101,7 @@ final class GorseTest extends TestCase
     public function testNonPersonalized()
     {
         $client = new Gorse(self::ENDPOINT, self::API_KEY);
-        // Test getLatest which returns Score[]
         $items = $client->getLatest('3000', 3);
-        $this->assertIsArray($items);
-        foreach ($items as $item) {
-            $this->assertInstanceOf(Score::class, $item);
-            $this->assertNotEmpty($item->id);
-        }
+        $this->assertCount(3, $items);
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: get_recommend now returns array of Score objects instead of array of strings

- Uses X-API-Version: 2 header to return recommendation scores
- Related: https://github.com/gorse-io/gorse/pull/1140