### PR TITLE
feat: add SearchItems API

### DIFF
--- a/src/Gorse.php
+++ b/src/Gorse.php
@@ -66,6 +66,20 @@ final class Gorse
     }
 
     /**
+     * @return Item[]
+     * @throws GuzzleException
+     */
+    function searchItems(string $query, int $n = 10): array
+    {
+        $items = [];
+        $response = $this->request('GET', '/api/items', null, ['q' => $query, 'n' => $n]);
+        foreach ($response->Items as $item) {
+            $items[] = Item::fromJSON($item);
+        }
+        return $items;
+    }
+
+    /**
      * @throws GuzzleException
      */
     function deleteItem(string $item_id): RowAffected

--- a/test/GorseTest.php
+++ b/test/GorseTest.php
@@ -44,6 +44,10 @@ final class GorseTest extends TestCase
     {
         $client = new Gorse(self::ENDPOINT, self::API_KEY);
 
+        $items = $client->searchItems("Toy Story", 3);
+        $this->assertNotEmpty($items);
+        $this->assertEquals("Toy Story (1995)", $items[0]->comment);
+
         $item = new Item("2000", true, array("Comedy", "Animation"), "2022-11-20T13:55:27Z", array("comedy", "movie"), "Minions (2015)");
         $rowsAffected = $client->insertItem($item);
         $this->assertEquals(1, $rowsAffected->rowAffected);


### PR DESCRIPTION
## Summary
- Adds `searchItems` returning typed `Item` objects and using Guzzle query parameters.
- Call `GET /api/items?q=<query>&n=<n>` following gorse-io/gorse-go#16
- Add item-search integration coverage

## Test Plan
- `docker run ... ./vendor/bin/phpunit --filter testItems test`
