### PR TITLE
feat: support multiple recommendation categories

### DIFF
--- a/src/Gorse.php
+++ b/src/Gorse.php
@@ -9,6 +9,7 @@ use Gorse\Model\Score;
 use Gorse\Model\User;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\RequestOptions;
 use stdClass;
 
@@ -140,14 +141,15 @@ final class Gorse
      * Uses X-API-Version: 2 header to return scores.
      * @throws GuzzleException
      */
-    function getRecommend(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0): array
+    function getRecommend(string $user_id, ?string $write_back_type = null, ?string $write_back_delay = null, int $n = 10, int $offset = 0, array $categories = []): array
     {
         $params = ['n' => $n, 'offset' => $offset];
         if ($write_back_type) $params['write-back-type'] = $write_back_type;
         if ($write_back_delay) $params['write-back-delay'] = $write_back_delay;
+        if ($categories) $params['category'] = $categories;
         
         $scores = [];
-        $response = $this->requestWithHeaders('GET', '/api/recommend/' . urlencode($user_id), null, $params, ['X-API-Version' => '2']);
+        $response = $this->requestWithHeaders('GET', '/api/recommend/' . urlencode($user_id) . '?' . Query::build($params), null, [], ['X-API-Version' => '2']);
         foreach ($response as $score) {
             $scores[] = Score::fromJSON($score);
         }

--- a/test/GorseTest.php
+++ b/test/GorseTest.php
@@ -102,6 +102,22 @@ final class GorseTest extends TestCase
     /**
      * @throws GuzzleException
      */
+    public function testRecommendMultipleCategories()
+    {
+        $client = new Gorse(self::ENDPOINT, self::API_KEY);
+        $client->insertUser(new User("3000", array(), ""));
+        $items = $client->getRecommend('3000', null, null, 3, 0, ['Drama', 'Comedy']);
+
+        $this->assertCount(3, $items);
+        foreach ($items as $score) {
+            $item = $client->getItem($score->id);
+            $this->assertNotEmpty(array_intersect(['Drama', 'Comedy'], $item->categories));
+        }
+    }
+
+    /**
+     * @throws GuzzleException
+     */
     public function testLatest()
     {
         $client = new Gorse(self::ENDPOINT, self::API_KEY);


### PR DESCRIPTION
## Summary

- add multiple-category filtering to `getRecommend`
- encode categories as repeated `category` query parameters expected by Gorse
- verify filtering through the real Gorse MovieLens test server

## Tests

- `vendor/bin/phpunit --filter testRecommendMultipleCategories test/GorseTest.php`
- `vendor/bin/phpunit test`
- PHP syntax checks for `src` and `test`

Local result: 6 tests, 23 assertions.